### PR TITLE
Upgrade Dompdf version to 0.8.x

### DIFF
--- a/code/SS_DOMPDF.php
+++ b/code/SS_DOMPDF.php
@@ -1,6 +1,7 @@
 <?php
 namespace Burnbright\SS_DOMPDF;
 
+use Dompdf\Dompdf;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\FileNameFilter;
 use SilverStripe\Assets\Folder;
@@ -20,8 +21,7 @@ class SS_DOMPDF
         define('DOMPDF_ENABLE_AUTOLOAD', false);
 
         //set configuration
-        require_once str_replace(DIRECTORY_SEPARATOR, '/', BASE_PATH . "/vendor/dompdf/dompdf/dompdf_config.inc.php");
-        $this->dompdf = new \DOMPDF();
+        $this->dompdf = new Dompdf();
         $this->dompdf->set_base_path(BASE_PATH);
         $this->dompdf->set_host(Director::absoluteBaseURL());
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "SilverStripe PDF Generation via DOMPDF Library",
     "type": "silverstripe-vendormodule",
     "require": {
-        "dompdf/dompdf": "^0.6.0"
+        "dompdf/dompdf": "^0.8.0"
     },
     "extra": {
         "installer-name": "silverstripe-dompdf"


### PR DESCRIPTION
Using the SS4 version I was getting "no block level parent found" errors from Dompdf. These were fixed in the latest version (0.8.2) so I tried upgrading and it resolved my problem.

I had to remove the line that loads the Dompdf config file because that was removed in v0.7.0. I'm assuming that it uses sensible defaults. :)
